### PR TITLE
Use ConfigManager helper methods for firmware flashing

### DIFF
--- a/modules/flasher.py
+++ b/modules/flasher.py
@@ -25,12 +25,14 @@ class Flasher:
         self.is_flashing = False
         self.flashing_lock = threading.Lock()  # Ensure only one flashing process runs at a time
 
-    def download_and_flash(self, side):
-        """Flash firmware for the specified side, downloading if needed."""
+    def download_and_flash(self, firmware_key):
+        """Flash firmware for the specified side or firmware key, downloading if needed."""
         def task():
-            info = self.config_manager.get_firmware_info(side)
+            info = self.config_manager.get_firmware_info(firmware_key)
             if not info:
-                self.logger.terminal_print(f"No firmware information for side: {side}")
+                self.logger.terminal_print(
+                    f"No firmware information for side: {firmware_key}"
+                )
                 return
             bin_filename = info["filename"]
             bin_path = get_download_path(bin_filename)
@@ -46,7 +48,9 @@ class Flasher:
                 return
 
             try:
-                primary_url, fallback_url = info["primary_url"], info["fallback_url"]
+                primary_url, fallback_url = self.config_manager.get_firmware_urls(
+                    firmware_key
+                )
                 primary_server = "GitHub"
                 fallback_server = "Gitee"
                 last_successful_server = self.config_manager.get_config_value("last_successful_server")

--- a/modules/gui.py
+++ b/modules/gui.py
@@ -800,22 +800,27 @@ class GUI:
         else:
             self.logger.terminal_print("File does not exist.")
 
-    def handle_flash(self, direction):
+    def handle_flash(self, firmware_key):
         """
-        Handle flashing for left or right direction, using pre-downloaded or online files.
+        Handle flashing for the specified side or firmware key, using pre-downloaded
+        or online files.
         """
-        info = self.config_manager.get_firmware_info(direction)
+        info = self.config_manager.get_firmware_info(firmware_key)
         if not info:
-            self.logger.terminal_print(f"No firmware file found for direction: {direction}")
+            self.logger.terminal_print(
+                f"No firmware file found for direction: {firmware_key}"
+            )
             return
         filename = info["filename"]
 
         if self.updater.is_offline or not self.config_manager.is_online_status():
-            self.logger.terminal_print("Offline mode detected. Please select your .bin file.")
+            self.logger.terminal_print(
+                "Offline mode detected. Please select your .bin file."
+            )
             self.offline_flash_dialog()
         else:
             self.logger.terminal_print(f"Attempting to flash {filename}")
-            self.flasher.download_and_flash(direction)
+            self.flasher.download_and_flash(firmware_key)
 
     def offline_flash_dialog(self):
         """


### PR DESCRIPTION
## Summary
- Allow `download_and_flash` to take a firmware key and resolve filenames/URLs through `ConfigManager`
- Update GUI flash handler to pass firmware key and log dynamic filename

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689fe426d0c0832d8ac376bab8501b6b