### PR TITLE
Use dynamic firmware metadata for updates and flashing

### DIFF
--- a/modules/gui.py
+++ b/modules/gui.py
@@ -114,7 +114,7 @@ class GUI:
         self.main_folder = get_main_folder()
 
         # Create Updater and run check
-        self.updater = Updater(self.logger, self.config_manager)
+        self.updater = Updater(self.logger, self.config_manager, self.flasher)
         self.updater.check_for_updates()
 
         # Start serial monitoring


### PR DESCRIPTION
## Summary
- Query ConfigManager for firmware versions and file names instead of hardcoded constants
- Build update messages using metadata and trigger Flasher with resolved firmware names
- Pass Flasher into Updater so firmware flashing can be initiated automatically

## Testing
- `python -m py_compile modules/updater.py modules/gui.py`


------
https://chatgpt.com/codex/tasks/task_e_689fe7422c60832da8799738efcce215