### PR TITLE
Unify firmware metadata with direct download URLs

### DIFF
--- a/config.json
+++ b/config.json
@@ -13,29 +13,23 @@
             ]
         }
     ],
-    "firmware_version": {
-        "left": {
-            "version": "3.2",
-            "changelog": []
-        },
-        "right": {
-            "version": "3.4",
-            "changelog": []
-        }
-    },
-    "config": {
-        "init_files": 1
-    },
     "firmware": {
         "left": {
+            "version": "3.2",
+            "changelog": [],
             "name": "V3.2_LEFT",
             "primary_url": "https://github.com/terrafirma2021/MAKCM_v2_files/raw/main/V3.2_LEFT.bin",
             "fallback_url": "https://gitee.com/terrafirma/MAKCM_v2_files/raw/main/V3.2_LEFT.bin"
         },
         "right": {
-            "name": "V3.2_RIGHT",
-            "primary_url": "https://github.com/terrafirma2021/MAKCM_v2_files/raw/main/V3.2_RIGHT.bin",
-            "fallback_url": "https://gitee.com/terrafirma/MAKCM_v2_files/raw/main/V3.2_RIGHT.bin"
+            "version": "3.4",
+            "changelog": [],
+            "name": "V3.4_RIGHT",
+            "primary_url": "https://github.com/terrafirma2021/MAKCM_v2_files/raw/main/V3.4_RIGHT.bin",
+            "fallback_url": "https://gitee.com/terrafirma/MAKCM_v2_files/raw/main/V3.4_RIGHT.bin"
         }
+    },
+    "config": {
+        "init_files": 1
     }
 }

--- a/modules/config_manager.py
+++ b/modules/config_manager.py
@@ -15,6 +15,9 @@ class ConfigManager:
     Handles downloading, storing, and accessing configuration data and firmware BIN files.
     Tracks online/offline state and selects the fastest server (GitHub or Gitee) based on ping latency.
     Downloads config.json and BIN files in the background on initialization.
+    Firmware entries live under the ``firmware`` key and provide ``name``,
+    ``version``, ``changelog``, ``primary_url``, and ``fallback_url`` fields
+    for each side (``left``/``right``).
     """
     PRIMARY_CONFIG_URL = "https://raw.githubusercontent.com/terrafirma2021/MAKCM_v2_files/main/config.json"
     FALLBACK_CONFIG_URL = "https://gitee.com/terrafirma/MAKCM_v2_files/raw/main/config.json"
@@ -314,11 +317,15 @@ class ConfigManager:
             return None
         urls = self.bin_file_urls.get(filename, {})
         name = filename[:-4] if filename.endswith('.bin') else filename
+        with self.config_lock:
+            firmware_entry = self.config_data.get("firmware", {}).get(side, {})
         return {
             "name": name,
             "filename": filename,
             "primary_url": urls.get("primary"),
             "fallback_url": urls.get("fallback"),
+            "version": firmware_entry.get("version"),
+            "changelog": firmware_entry.get("changelog", []),
         }
 
     def get_firmware_urls(self, side):

--- a/modules/flasher.py
+++ b/modules/flasher.py
@@ -10,6 +10,9 @@ class Flasher:
     """
     Handles flashing firmware BIN files using pre-downloaded files when available.
     Falls back to online download if local files are missing.
+    Firmware details are provided by ConfigManager and include ``name``,
+    ``version``, ``changelog``, ``primary_url``, and ``fallback_url`` for
+    each side.
     """
     def __init__(self, logger, serial_handler, config_manager):
         self.logger = logger


### PR DESCRIPTION
## Summary
- consolidate firmware info into single `firmware` block with direct download URLs and names
- teach ConfigManager/Flasher/Updater about new firmware metadata fields
- document firmware structure for consistent consumption across modules

## Testing
- `python -m py_compile main.py modules/config_manager.py modules/flasher.py modules/updater.py modules/gui.py`


------
https://chatgpt.com/codex/tasks/task_e_689fe9c91800832db802a0d41d59284d